### PR TITLE
Added update_or_create()

### DIFF
--- a/lib/DBIx/Class/Wrapper/Factory.pm
+++ b/lib/DBIx/Class/Wrapper/Factory.pm
@@ -146,6 +146,20 @@ sub single {
   return $original ? $self->wrap($original) : undef;
 }
 
+=head2 update_or_create
+
+Wraps around the original DBIC update_or_create method.
+
+See L<DBIx::Class::ResultSet/update_or_create>
+
+=cut
+
+sub update_or_create {
+    my ($self, $args) = @_;
+    my $original = $self->dbic_rs->update_or_create($args);
+    return $original ? $self->wrap($original) : undef;
+}
+
 =head2 find_or_create
 
 Wraps around the original DBIC find_or_create method.

--- a/t/01-dbic_wrapper.t
+++ b/t/01-dbic_wrapper.t
@@ -151,5 +151,23 @@ subtest 'find_or_new' => sub {
     is( $result2->in_storage(), 1, 'The result is in storage this time' );
 };
 
+subtest 'update_or_create' => sub {
+    ok( $pf->count() == 0, 'Initially, there are no products' );
+    $pf->update_or_create({
+        id         => 1,
+        name       => 'Cherry Coke',
+        colour     => 'red',
+        builder_id => 1,
+    });
+    ok( $pf->count() == 1, 'update_or_create() made a new row' );
+    $pf->update_or_create({
+        id         => 1,    # deliberate PRIMARY key collision
+        name       => 'Diet Coke',
+        colour     => 'silver',
+        builder_id => 1,
+    });
+    ok( $pf->count() == 1, 'update_or_create() updated an existing row' );
+    ok( $pf->find(1)->colour() eq 'silver', 'updated colour found' );
+};
 
 done_testing();

--- a/t/lib/My/Model/O/Product.pm
+++ b/t/lib/My/Model/O/Product.pm
@@ -1,7 +1,7 @@
 package My::Model::O::Product;
 use Moose;
 extends 'DBIx::Class::Wrapper::Object';
-has 'o' => ( is => 'ro' , required => 1 , handles => [ 'id' , 'name' ] );
+has 'o' => ( is => 'ro' , required => 1 , handles => [ 'id' , 'name', 'colour' ] );
 sub turn_on{
     my ($self) = @_;
     return "Turning on $self";


### PR DESCRIPTION
...which calls the underlying DBIx::Class::ResultSet::update_or_create

Request for Broadbean story SEAR-2675 to handle PRIMARY key collisions gracefully.